### PR TITLE
Rename `filter.isAllowed` interface method as `filter.IsAllowed` so it is exposed as a public method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cli/cli
 coverage.out
 output.jpg
 output.png
+vendor

--- a/color_cut_quantizer.go
+++ b/color_cut_quantizer.go
@@ -144,7 +144,7 @@ func (q *ColorCutQuantizer) Quantize(p color.Palette, m image.Image) color.Palet
 
 func (q *ColorCutQuantizer) shouldIgnoreColor(color color.Color) bool {
 	for _, filter := range q.filters {
-		if !filter.isAllowed(color) {
+		if !filter.IsAllowed(color) {
 			return true
 		}
 	}

--- a/filter.go
+++ b/filter.go
@@ -9,7 +9,7 @@ import (
 // are valid within a resulting Palette.
 type Filter interface {
 	// Hook to allow clients to be able filter colors from resulting palette.  Return true if the color is allowed, false if not.
-	isAllowed(c color.Color) bool
+	IsAllowed(c color.Color) bool
 }
 
 // Default values for the default filter.
@@ -28,7 +28,7 @@ type defaultFilter struct {
 	quantizedWhiteMask    uint16
 }
 
-func (f *defaultFilter) isAllowed(c color.Color) bool {
+func (f *defaultFilter) IsAllowed(c color.Color) bool {
 	// Short circuit for quantized colors to allow for faster black/white checking.
 	if q, ok := c.(QuantizedColor); ok && !f.isAllowedQuantizedColor(q) {
 		return false

--- a/filter_test.go
+++ b/filter_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestDefaultFilter_isAllowed(t *testing.T) {
+func TestDefaultFilter_IsAllowed(t *testing.T) {
 	testData := map[color.Color]bool{
 		HSL{0, 1.0, 0.049, 255}: false,
 		HSL{0, 1.0, 0.050, 255}: false,
@@ -16,7 +16,7 @@ func TestDefaultFilter_isAllowed(t *testing.T) {
 		HSL{0, 1.0, 0.951, 255}: false,
 	}
 	for c, expected := range testData {
-		if expected != DefaultFilter.isAllowed(c) {
+		if expected != DefaultFilter.IsAllowed(c) {
 			if expected {
 				t.Errorf("Expected color %v to be allowed.\n", c)
 			} else {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/RobCherry/vibrant
+
+go 1.24.2
+
+require golang.org/x/image v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/image v0.26.0 h1:4XjIFEZWQmCZi6Wv8BoxsDhRU3RVnLX04dToTDAEPlY=
+golang.org/x/image v0.26.0/go.mod h1:lcxbMFAovzpnJxzXS3nyL83K27tmqtKzIJpctK8YO5c=


### PR DESCRIPTION
This PR rename `filter.isAllowed` interface method as `filter.IsAllowed` so it is exposed as a public method. This allows filters to be defined and used in packages outside of `vibrant`.

Additionally, this PR adds `go.mod` file. It also explicitly excludes the `vendor` directory from version control. Personally I like versioning things but that seems it should be your choice.